### PR TITLE
Fix: Restore whitespace handling, prevent cursor jump and fix newline collapsing issues

### DIFF
--- a/src/components/Editor/TipTapEditor.tsx
+++ b/src/components/Editor/TipTapEditor.tsx
@@ -67,6 +67,11 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
               "border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic",
           },
         },
+        paragraph: {
+          HTMLAttributes: {
+            class: "min-h-[1em]",
+          },
+        },
       }),
       CodeBlock.configure({
         HTMLAttributes: {
@@ -177,9 +182,10 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
 
   // Update editor content when initialContent changes
   useEffect(() => {
-    if (editor && initialContent) {
-      editor.commands.setContent(initialContent);
-    }
+    if (!editor) return;
+    const incomingContent = initialContent ?? "";
+    if (editor.getHTML() === incomingContent) return;
+    editor.commands.setContent(incomingContent);
   }, [editor, initialContent]);
 
   const formatText = useCallback(

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,7 @@
 @layer components {
   .prose {
     @apply text-gray-700 dark:text-gray-300 leading-relaxed;
+    white-space: pre-wrap;
   }
   
   .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
@@ -199,6 +200,7 @@
     background: transparent;
     overflow-y: auto;
     height: 100%;
+    white-space: pre-wrap;
   }
 
   @media (min-width: 640px) {
@@ -208,7 +210,13 @@
   }
 
   .ProseMirror p {
-    word-wrap: break-word;
+    overflow-wrap: break-word;
+    min-height: 1em;
+  }
+
+  .ProseMirror p:empty::before {
+    content: '\200B';
+    display: inline;
   }
 
   .ProseMirror p.is-editor-empty:first-child::before {


### PR DESCRIPTION
- Bug Fixes
  - Preserves spaces and newlines in the editor so whitespace no longer collapses.
  - Prevents unnecessary content resets to stop cursor jumping and flicker.
  - Keeps empty paragraphs visible so multiple blank lines and layout are retained.
