### PR TITLE
Fix: Preserve multiple consecutive newlines in TipTap editor

### DIFF
--- a/src/components/Editor/TipTapWrapper.tsx
+++ b/src/components/Editor/TipTapWrapper.tsx
@@ -156,14 +156,13 @@ const TipTapWrapper: React.FC<TipTapWrapperProps> = ({
             });
             break;
           case "p":
-            if (content && content.trim().length > 0) {
-              blocks.push({
-                id: `block-${blockId++}`,
-                type: "text",
-                content,
-                htmlContent,
-              });
-            }
+            // Always preserve paragraph blocks, even if empty (for proper newline handling)
+            blocks.push({
+              id: `block-${blockId++}`,
+              type: "text",
+              content: content || "",
+              htmlContent,
+            });
             break;
           default:
             // For other elements, only process if they have meaningful content

--- a/src/index.css
+++ b/src/index.css
@@ -212,11 +212,18 @@
   .ProseMirror p {
     overflow-wrap: break-word;
     min-height: 1em;
+    margin: 0;
+    padding: 0;
+  }
+
+  .ProseMirror p:empty {
+    min-height: 1em;
   }
 
   .ProseMirror p:empty::before {
     content: '\200B';
-    display: inline;
+    display: inline-block;
+    width: 0;
   }
 
   .ProseMirror p.is-editor-empty:first-child::before {


### PR DESCRIPTION
# Fix: Multiple Newlines Collapsing to Single Line

## Issue
When users pressed Enter multiple times to create blank lines, only one blank line would remain after typing resumed. Multiple consecutive newlines were being collapsed into a single newline.

## Root Cause
The `TipTapWrapper.tsx` HTML-to-blocks conversion was filtering out empty `<p>` elements:
```typescript
// Previous code - filtered out empty paragraphs
if (content && content.trim().length > 0) {
  blocks.push({...});
}
```

This caused all empty paragraph nodes to be removed during the conversion process, collapsing multiple newlines.

## Solution
1. **HTML-to-blocks conversion**: Modified to always preserve paragraph blocks, even when empty
2. **Enhanced CSS**: Improved empty paragraph handling with `inline-block` zero-width space and explicit sizing

## Changes Made
- `src/components/Editor/TipTapWrapper.tsx`: Remove empty content filter for paragraphs
- `src/index.css`: Enhanced empty paragraph CSS rules